### PR TITLE
gen3_data_library -> gen3_user_data_library

### DIFF
--- a/gen3userdatalibrary/auth.py
+++ b/gen3userdatalibrary/auth.py
@@ -67,7 +67,7 @@ async def authorize_request(
     try:
         is_authorized = await arborist.auth_request(
             token.credentials,
-            service="gen3_data_library",
+            service="gen3_user_data_library",
             methods=authz_access_method,
             resources=authz_resources,
         )

--- a/gen3userdatalibrary/metrics.py
+++ b/gen3userdatalibrary/metrics.py
@@ -5,18 +5,18 @@ from cdispyutils.metrics import BaseMetrics
 from gen3userdatalibrary import config
 
 TOTAL_USER_LIST_GAUGE = {
-    "name": "gen3_data_library_user_lists",
+    "name": "gen3_user_data_library_user_lists",
     "description": "Gen3 User Data Library User Lists",
 }
 
 API_USER_LIST_COUNTER = {
-    "name": "gen3_data_library_api_user_lists",
+    "name": "gen3_user_data_library_api_user_lists",
     "description": "API requests for modifying Gen3 User Data Library User Lists. This includes "
     "all CRUD actions.",
 }
 
 API_USER_LIST_ITEM_COUNTER = {
-    "name": "gen3_data_library_user_api_list_items",
+    "name": "gen3_user_data_library_user_api_list_items",
     "description": "API requests for modifying Items within Gen3 User Data Library User "
     "Lists. This includes all CRUD "
     "actions.",

--- a/gen3userdatalibrary/routes/context_configurations.py
+++ b/gen3userdatalibrary/routes/context_configurations.py
@@ -20,15 +20,15 @@ Current recognized properties:
 """
 ENDPOINT_TO_CONTEXT = {
     "redirect_to_docs": {
-        "resource": "/gen3_data_library/service_info/redoc",
+        "resource": "/gen3_user_data_library/service_info/redoc",
         "method": "read",
     },
     "get_version": {
-        "resource": "/gen3_data_library/service_info/version",
+        "resource": "/gen3_user_data_library/service_info/version",
         "method": "read",
     },
     "get_status": {
-        "resource": "/gen3_data_library/service_info/status",
+        "resource": "/gen3_user_data_library/service_info/status",
         "method": "read",
     },
     "read_all_lists": {


### PR DESCRIPTION

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Change gen3_data_library to gen3_user_data_library to align with expected arborist policies.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
