### PR TITLE
Change role_ids to library_owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,30 @@ Third, with the prior two steps established, we authorize incoming requests
 to ensure that a user who is defined in our system has access to the list
 they're requesting to view.
 
+The `library_owner` role should be created in arborist:
+```yaml
+roles:
+  - id: 'library_owner'
+    description: ''
+    permissions:
+    - id: 'library_reader'
+      action:
+        method: read
+        service: 'gen3-user-data-library'
+    - id: 'library_creator'
+      action:
+        method: create
+        service: 'gen3-user-data-library'
+    - id: 'library_updater'
+      action:
+        method: update
+        service: 'gen3-user-data-library'
+    - id: 'library_deleter'
+      action:
+        method: delete
+        service: 'gen3-user-data-library'
+```
+
 ## Dev Considerations
 
 If you add a new endpoint, please refer

--- a/gen3userdatalibrary/auth.py
+++ b/gen3userdatalibrary/auth.py
@@ -67,7 +67,7 @@ async def authorize_request(
         user_id = "Unknown"
     is_authorized = await arborist.auth_request(
         token.credentials,
-        service="gen3_user_data_library",
+        service="gen3-user-data-library",
         methods=authz_access_method,
         resources=authz_resources,
     )
@@ -270,7 +270,7 @@ async def create_user_policy(
 
     await arborist_client.create_user_if_not_exist(username)
     logging.info(f"Policy does not exist for user_id {user_id}")
-    role_ids = ["create", "read", "update", "delete"]
+    role_ids = ["library_owner"]
 
     logging.info("Attempting to create arborist resource: {}".format(resource))
     await arborist_client.update_resource(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -97,7 +97,7 @@ async def test_authorize_request_successful(
 
     mock_arborist.auth_request.assert_called_once_with(
         "mock-token",
-        service="gen3_user_data_library",
+        service="gen3-user-data-library",
         methods="access",
         resources=["/example"],
     )
@@ -297,7 +297,7 @@ async def test_create_user_policy_resource_user_not_found(monkeypatch):
         policy_json={
             "id": user_id,
             "description": "policy created by gen3-user-data-library",
-            "role_ids": ["create", "read", "update", "delete"],
+            "role_ids": ["library_owner"],
             "resource_paths": [resource],
         },
         create_if_not_exist=True,
@@ -337,7 +337,7 @@ async def test_create_user_policy_create_resource_success(monkeypatch):
         policy_json={
             "id": user_id,
             "description": "policy created by gen3-user-data-library",
-            "role_ids": ["create", "read", "update", "delete"],
+            "role_ids": ["library_owner"],
             "resource_paths": [resource],
         },
         create_if_not_exist=True,
@@ -399,7 +399,7 @@ async def test_create_user_policy_policy_creation_failure(monkeypatch):
         policy_json={
             "id": user_id,
             "description": "policy created by gen3-user-data-library",
-            "role_ids": ["create", "read", "update", "delete"],
+            "role_ids": ["library_owner"],
             "resource_paths": [resource],
         },
         create_if_not_exist=True,
@@ -439,7 +439,7 @@ async def test_create_user_policy_grant_failure(monkeypatch):
         policy_json={
             "id": user_id,
             "description": "policy created by gen3-user-data-library",
-            "role_ids": ["create", "read", "update", "delete"],
+            "role_ids": ["library_owner"],
             "resource_paths": [resource],
         },
         create_if_not_exist=True,


### PR DESCRIPTION
Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- Uses library_owner role in arborist to assign permissions for user managed lists rather than generic "create", "read", "update", "delete" roles. 

### Dependency updates

### Deployment changes
- user.yaml should be updated to include library_owner role. See https://github.com/uc-cdis/gen3-user-data-library/blob/47ab4040f6947d02ea37823a4a8a39c979b46b59/README.md#authz for more details.
<!-- This section should only contain important things devops should know when updating service versions. -->
