### PR TITLE
fix(BDC-614): Remove dynamic worker count

### DIFF
--- a/gen3userdatalibrary/config.py
+++ b/gen3userdatalibrary/config.py
@@ -52,6 +52,9 @@ PROMETHEUS_MULTIPROC_DIR = config(
     "PROMETHEUS_MULTIPROC_DIR", default="/var/tmp/prometheus_metrics"
 )
 
+# gunicorn setting for the number of workers to spawn, see https://docs.gunicorn.org/en/stable/settings.html#workers
+GUNICORN_WORKERS = config("GUNICORN_WORKERS", default=3)
+
 # Location of the policy engine service, Arborist
 # Defaults to the default service name in k8s magic DNS setup
 ARBORIST_URL = config("ARBORIST_URL", default="http://arborist-service")

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,5 +1,4 @@
 import logging
-import multiprocessing
 
 import cdislogging
 import gunicorn.glogging
@@ -53,8 +52,7 @@ logger_class = CustomLogger
 wsgi_app = "gen3userdatalibrary.main:app_instance"
 bind = "0.0.0.0:8000"
 
-# NOTE: This is always more than 2
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = gen3userdatalibrary.config.GUNICORN_WORKERS
 
 # default was `30` for the 2 below
 timeout = 90


### PR DESCRIPTION
Replaces dynamic worker count with explicit use of gunicorn's WEB_CONCURRENCY environment variable in the env file.

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Prevents data library from using all cpus available on a given node the container for the service is running
### Improvements

### Dependency updates

### Deployment changes
- Worker counts are no longer dynamically calculated and must be set via GUNICORN_WORKERS in the .env file. It defaults to 3.
<!-- This section should only contain important things devops should know when updating service versions. -->
