### PR TITLE
Change GUNICORN_WORKERS default to 1

### DIFF
--- a/gen3userdatalibrary/config.py
+++ b/gen3userdatalibrary/config.py
@@ -57,7 +57,7 @@ PROMETHEUS_MULTIPROC_DIR = config(
 )
 
 # gunicorn setting for the number of workers to spawn, see https://docs.gunicorn.org/en/stable/settings.html#workers
-GUNICORN_WORKERS = config("GUNICORN_WORKERS", default=3)
+GUNICORN_WORKERS = config("GUNICORN_WORKERS", default=1)
 
 # Location of the policy engine service, Arborist
 # Defaults to the default service name in k8s magic DNS setup


### PR DESCRIPTION


Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
- Updates default gunicorn workers to 1
<!-- This section should only contain important things devops should know when updating service versions. -->
